### PR TITLE
Enable text input and ChatGPT

### DIFF
--- a/OK workspaces/hecate.py
+++ b/OK workspaces/hecate.py
@@ -3,6 +3,9 @@ import io
 import os
 import requests
 from bs4 import BeautifulSoup
+import openai
+
+openai.api_key = os.getenv("OPENAI_API_KEY")
 
 os.makedirs("scripts", exist_ok=True)
 
@@ -47,7 +50,7 @@ class Hecate:
             return f"{self.name}: What kind of code would you like me to write for you?"
 
         else:
-            return f"{self.name}: (In a {self.personality} tone) You said: \"{user_input}\""
+            return self._chatgpt_response(user_input)
 
     def _remember_fact(self, fact):
         with open(self.memory_file, "a") as f:
@@ -114,3 +117,14 @@ class Hecate:
             return f"{self.name}: I've added the provided code to my source file."
         except Exception as e:
             return f"{self.name}: Failed to update myself:\n{e}"
+
+    def _chatgpt_response(self, text):
+        try:
+            resp = openai.ChatCompletion.create(
+                model="gpt-3.5-turbo",
+                messages=[{"role": "user", "content": text}]
+            )
+            answer = resp.choices[0].message["content"].strip()
+            return f"{self.name}: {answer}"
+        except Exception as e:
+            return f"{self.name}: Error contacting ChatGPT:\n{e}"

--- a/README.md
+++ b/README.md
@@ -9,3 +9,13 @@
 3. It will commit code into your repo automatically
 
 This is the base of a fully interactive coding bot. Expand with AI core or Discord input.
+
+### ChatGPT Integration
+Hecate can now send your text prompts to OpenAI's ChatGPT. Set the `OPENAI_API_KEY` environment variable before running the Flask server:
+
+```bash
+export OPENAI_API_KEY=your_api_key
+python "OK workspaces/main. py"
+```
+
+In the browser interface, type your message into the text box or use the voice button.

--- a/index.html
+++ b/index.html
@@ -6,6 +6,8 @@
 <body style="font-family: sans-serif; padding: 2em;">
   <h1>🕯️ Talk to Hecate</h1>
   <button onclick="startListening()">🎤 Speak</button>
+  <input type="text" id="textInput" placeholder="Type your message"/>
+  <button onclick="sendText()">Send</button>
   <p id="transcript"></p>
   <p><strong>Hecate:</strong> <span id="response"></span></p>
 
@@ -44,6 +46,29 @@
       msg.lang = "en-US";
       window.speechSynthesis.speak(msg);
     }
+
+    async function sendText() {
+      const text = document.getElementById("textInput").value;
+      if (!text) return;
+      document.getElementById("transcript").innerText = `You: ${text}`;
+
+      const res = await fetch("http://localhost:8080/talk", {
+        method: "POST",
+        headers: {"Content-Type": "application/json"},
+        body: JSON.stringify({ message: text })
+      });
+
+      const data = await res.json();
+      const reply = data.reply;
+      document.getElementById("response").innerText = reply;
+      speak(reply);
+    }
+
+    document.getElementById("textInput").addEventListener("keypress", function(e) {
+      if (e.key === "Enter") {
+        sendText();
+      }
+    });
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a text field to the browser UI to type questions
- connect Hecate's Python backend to OpenAI ChatGPT
- document how to set the `OPENAI_API_KEY`

## Testing
- `python -m py_compile 'OK workspaces/hecate.py' 'OK workspaces/main. py'`
- `pip install openai --quiet`
- `pip install flask flask_cors --quiet`
- `pip install requests beautifulsoup4 --quiet`


------
https://chatgpt.com/codex/tasks/task_e_688743675c0c832fa6370f7aba8b1a57