### PR TITLE
Enable browser location tagging with email feature

### DIFF
--- a/OK workspaces/hecate.py
+++ b/OK workspaces/hecate.py
@@ -22,6 +22,7 @@ class Hecate:
         self.last_code = ""
         self.gmail_user = os.getenv("GMAIL_USER")
         self.gmail_pass = os.getenv("GMAIL_PASS")
+        self.current_location = None
 
     def respond(self, user_input):
         if user_input.startswith("remember:"):
@@ -58,6 +59,21 @@ class Hecate:
                 return self._send_email(to.strip(), subject.strip(), body.strip())
             except ValueError:
                 return f"{self.name}: Use 'email:recipient|subject|body'"
+
+        elif user_input.startswith("location:"):
+            try:
+                parts = user_input.split("location:", 1)[1].split("|")
+                lat = parts[0].strip()
+                lon = parts[1].strip()
+                self.current_location = (lat, lon)
+                if len(parts) > 2:
+                    to = parts[2].strip()
+                    subject = "Location Data"
+                    body = f"Latitude: {lat}\nLongitude: {lon}"
+                    return self._send_email(to, subject, body)
+                return f"{self.name}: Location tagged at {lat}, {lon}."
+            except Exception:
+                return f"{self.name}: Use 'location:lat|lon|email'"
 
         elif user_input.startswith("inbox"):
             try:

--- a/README.md
+++ b/README.md
@@ -29,3 +29,7 @@ export GMAIL_PASS=your_app_password
 ```
 
 Use the commands `email:recipient|subject|body` to send an email and `inbox:n` to read your latest `n` emails.
+
+### Location Tagging
+Capture your current browser location and email it using the command format `location:lat|lon|recipient`.
+The web interface provides buttons to fetch your coordinates and send them via email.

--- a/index.html
+++ b/index.html
@@ -9,6 +9,10 @@
   <input type="text" id="textInput" placeholder="Type your message"/>
   <button onclick="sendText()">Send</button>
   <p id="transcript"></p>
+  <p id="location"></p>
+  <input type="text" id="emailInput" placeholder="Email address" />
+  <button onclick="getLocation()">📍 Get Location</button>
+  <button onclick="emailLocation()">Email Location</button>
   <p><strong>Hecate:</strong> <span id="response"></span></p>
 
   <script>
@@ -40,12 +44,49 @@
       recognition.start();
     }
 
-    function speak(text) {
-      const msg = new SpeechSynthesisUtterance();
-      msg.text = text;
-      msg.lang = "en-US";
-      window.speechSynthesis.speak(msg);
+  function speak(text) {
+    const msg = new SpeechSynthesisUtterance();
+    msg.text = text;
+    msg.lang = "en-US";
+    window.speechSynthesis.speak(msg);
+  }
+
+  let currentLocation = null;
+  function getLocation() {
+    if (!navigator.geolocation) {
+      alert("Geolocation not supported.");
+      return;
     }
+    navigator.geolocation.getCurrentPosition(pos => {
+      const { latitude, longitude } = pos.coords;
+      currentLocation = { latitude, longitude };
+      document.getElementById("location").innerText = `Location: ${latitude}, ${longitude}`;
+    }, err => {
+      alert("Unable to retrieve location: " + err.message);
+    });
+  }
+
+  async function emailLocation() {
+    if (!currentLocation) {
+      alert("No location captured yet.");
+      return;
+    }
+    const to = document.getElementById("emailInput").value.trim();
+    if (!to) {
+      alert("Enter email address");
+      return;
+    }
+    const message = `location:${currentLocation.latitude}|${currentLocation.longitude}|${to}`;
+    const res = await fetch("http://localhost:8080/talk", {
+      method: "POST",
+      headers: {"Content-Type": "application/json"},
+      body: JSON.stringify({ message })
+    });
+    const data = await res.json();
+    const reply = data.reply;
+    document.getElementById("response").innerText = reply;
+    speak(reply);
+  }
 
     async function sendText() {
       const text = document.getElementById("textInput").value;


### PR DESCRIPTION
## Summary
- implement geolocation buttons in `index.html`
- add `location:` command handling in `hecate.py`
- document new location feature in `README`

## Testing
- `pip install flask flask_cors requests beautifulsoup4 openai`
- `python 'OK workspaces/main. py'` *(server started)*

------
https://chatgpt.com/codex/tasks/task_e_688745b5fb50832fa437f182c102ad57