### PR TITLE
Fix variable interpolation bug

### DIFF
--- a/ai_core.js
+++ b/ai_core.js
@@ -12,8 +12,8 @@ find . -type f -name "*.jpg" | while read file; do
   else
     date=$(date +"%Y-%m-%d")
     dir=$(dirname "$file")
-    mv "$file" "$dir/${date}_$base"
-    echo "Renamed $file -> $dir/${date}_$base"
+    mv "$file" "$dir/\${date}_$base"
+    echo "Renamed $file -> $dir/\${date}_$base"
   fi
 done
 `;


### PR DESCRIPTION
## Summary
- escape `${date}` in shell script generator to avoid Node interpolation

## Testing
- `node -c ai_core.js`
- `node -e "require('./ai_core.js').generateCodeFromPrompt('test','/tmp/test.sh')"`

------
https://chatgpt.com/codex/tasks/task_e_68874980e3bc832fa721c5020a9d68e9