### PR TITLE
Add GitHub automation script

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,15 @@
 > The daemon who codes, commits, and controls the flame of your GitHub repo.
 
 ### Usage
-1. Place your GitHub token in `config.json`
+1. Create a `config.json` file with your GitHub token and remote URL:
+   ```json
+   {
+     "token": "YOUR_GITHUB_TOKEN",
+     "remote": "https://github.com/username/repo.git"
+   }
+   ```
 2. Run `node hecate-auto.js`
-3. It will commit code into your repo automatically
+3. It will commit and push code to your repo automatically
 
 This is the base of a fully interactive coding bot. Expand with AI core or Discord input.
 

--- a/config.json
+++ b/config.json
@@ -1,0 +1,4 @@
+{
+  "token": "YOUR_GITHUB_TOKEN",
+  "remote": "https://github.com/username/repo.git"
+}

--- a/hecate-auto.js
+++ b/hecate-auto.js
@@ -1,0 +1,31 @@
+const { execSync } = require('child_process');
+const fs = require('fs');
+
+let config;
+try {
+  config = JSON.parse(fs.readFileSync('config.json', 'utf8'));
+} catch (e) {
+  console.error('Missing config.json');
+  process.exit(1);
+}
+
+const { token, remote } = config;
+if (!token || !remote) {
+  console.error('config.json must include "token" and "remote"');
+  process.exit(1);
+}
+
+function run(cmd) {
+  console.log('$ ' + cmd);
+  execSync(cmd, { stdio: 'inherit', env: process.env });
+}
+
+try {
+  run('git add -A');
+  run('git commit -m "Auto commit by Hecate"');
+} catch (e) {
+  console.log('Nothing to commit');
+}
+
+const url = remote.replace('https://', `https://${token}@`);
+run(`git push ${url}`);


### PR DESCRIPTION
## Summary
- create `config.json` template for GitHub token and repo URL
- add a `hecate-auto.js` Node script to auto-commit and push changes
- update README usage instructions

## Testing
- `node -c hecate-auto.js`
- `python -m py_compile 'OK workspaces/hecate.py'`


------
https://chatgpt.com/codex/tasks/task_e_68874a91db78832f8b5dd89e5b08a303