### PR TITLE
Add auto OpenAI key loading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 __pycache__/
+openai_key.txt

--- a/OK workspaces/hecate.py
+++ b/OK workspaces/hecate.py
@@ -9,7 +9,23 @@ import email
 from email.mime.text import MIMEText
 import openai
 
-openai.api_key = os.getenv("OPENAI_API_KEY")
+
+def _load_openai_key():
+    """Fetch the OpenAI API key from env or local file."""
+    key = os.getenv("OPENAI_API_KEY")
+    if key:
+        return key
+
+    # Try to read from openai_key.txt at repository root
+    root_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+    key_path = os.path.join(root_dir, "openai_key.txt")
+    if os.path.exists(key_path):
+        with open(key_path, "r") as f:
+            return f.read().strip()
+    return None
+
+
+openai.api_key = _load_openai_key()
 
 os.makedirs("scripts", exist_ok=True)
 

--- a/README.md
+++ b/README.md
@@ -17,10 +17,18 @@
 This is the base of a fully interactive coding bot. Expand with AI core or Discord input.
 
 ### ChatGPT Integration
-Hecate can now send your text prompts to OpenAI's ChatGPT. Set the `OPENAI_API_KEY` environment variable before running the Flask server:
+Hecate can now send your text prompts to OpenAI's ChatGPT. By default it looks
+for the API key in the `OPENAI_API_KEY` environment variable. If that isn't
+present, it will attempt to load a key from a file named `openai_key.txt` in the
+repository root.
 
 ```bash
+# Option 1: environment variable
 export OPENAI_API_KEY=your_api_key
+
+# Option 2: place the key in openai_key.txt
+echo your_api_key > openai_key.txt
+
 python "OK workspaces/main. py"
 ```
 


### PR DESCRIPTION
## Summary
- load OpenAI key from env or openai_key.txt
- document key loading in README
- ignore openai_key.txt in git

## Testing
- `python -m py_compile 'OK workspaces/hecate.py'`

------
https://chatgpt.com/codex/tasks/task_e_68874e3d6a70832fbd92881062e1426d