### PR TITLE
Add iOS zip packaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,15 @@ her own source file.
 
 Send a message starting with `selfupdate:` followed by Python code and Hecate
 will append that snippet to `hecate.py`.
+
+## Deploying on iPhone
+
+You can run Hecate locally on an iPhone using Pythonista 3 or a similar Python environment. A helper script `make_ios_zip.sh` is included to package the project files into a single zip archive.
+
+1. Run `./make_ios_zip.sh` on your computer. This creates `Hecate_ios.zip` with the necessary files.
+2. Transfer `Hecate_ios.zip` to your iPhone (AirDrop, iCloud, etc.).
+3. Open the zip file in Pythonista and extract the contents.
+4. In Pythonista, open `main. py` and run it. This starts the Flask server on port 8080.
+5. Open Safari and navigate to `http://localhost:8080` to use the web interface.
+
+The index page uses the Web Speech API, which works best in Safari on iOS 14 or later.

--- a/make_ios_zip.sh
+++ b/make_ios_zip.sh
@@ -1,0 +1,10 @@
+#!/bin/sh
+set -e
+ZIP_NAME="Hecate_ios.zip"
+
+# Remove old archive if exists
+[ -f "$ZIP_NAME" ] && rm "$ZIP_NAME"
+
+zip -r "$ZIP_NAME" "index.html" "README.md" "OK workspaces/hecate.py" "OK workspaces/main. py"
+
+echo "Created $ZIP_NAME with project files for iOS deployment."


### PR DESCRIPTION
## Summary
- allow packaging for iOS deployment
- document how to run Hecate on iPhone

## Testing
- `./make_ios_zip.sh`

------
https://chatgpt.com/codex/tasks/task_e_686b9f44e8b0832f88fbf86d40543521