### PR TITLE
Add requirements.txt to document dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+flask
+flask-cors
+requests
+beautifulsoup4
+openai


### PR DESCRIPTION
## Summary
- list Python dependencies for the Hecate server

## Testing
- `pip install -r requirements.txt`
- `python 'OK workspaces/main. py'`

------
https://chatgpt.com/codex/tasks/task_e_68722fff51b8832fbf63885aac191574