### PR TITLE
Switch backend to latest GPT model

### DIFF
--- a/OK workspaces/hecate.py
+++ b/OK workspaces/hecate.py
@@ -269,7 +269,7 @@ class Hecate:
     def _chatgpt_response(self, text):
         try:
             resp = openai.ChatCompletion.create(
-                model="gpt-3.5-turbo",
+                model="gpt-4o",
                 messages=[{"role": "user", "content": text}]
             )
             answer = resp.choices[0].message["content"].strip()

--- a/README.md
+++ b/README.md
@@ -17,7 +17,8 @@
 This is the base of a fully interactive coding bot. Expand with AI core or Discord input.
 
 ### ChatGPT Integration
-Hecate can now send your text prompts to OpenAI's ChatGPT. By default it looks
+Hecate can now send your text prompts to OpenAI's ChatGPT. It uses the `gpt-4o`
+model for generating replies. By default it looks
 for the API key in the `OPENAI_API_KEY` environment variable. If that isn't
 present, it will attempt to load a key from a file named `openai_key.txt` in the
 repository root.


### PR DESCRIPTION
## Summary
- upgrade ChatGPT backend call to `gpt-4o`
- mention the new model in the README

## Testing
- `python -m py_compile 'OK workspaces/hecate.py'`
- `python -m py_compile 'OK workspaces/main. py'`


------
https://chatgpt.com/codex/tasks/task_e_68879f157334832fbaf9d46d3cb0c2cd