### PR TITLE
Add memory summarization feature

### DIFF
--- a/OK workspaces/hecate.py
+++ b/OK workspaces/hecate.py
@@ -48,6 +48,9 @@ class Hecate:
         elif user_input == "recall":
             return self._recall_facts()
 
+        elif user_input == "summarize":
+            return self._summarize_memory()
+
         elif user_input.startswith("run:"):
             code = user_input.split("run:", 1)[1].strip()
             self.last_code = code
@@ -138,6 +141,28 @@ class Hecate:
         with open(self.memory_file, "r") as f:
             facts = f.read().strip()
         return f"{self.name}: Here's what I remember:\n{facts if facts else '(empty)'}"
+
+    def _summarize_memory(self):
+        """Return a short summary of remembered facts using ChatGPT."""
+        if not os.path.exists(self.memory_file):
+            return f"{self.name}: I don’t have any memories yet."
+        with open(self.memory_file, "r") as f:
+            facts = f.read().strip()
+        if not facts:
+            return f"{self.name}: Memory file is empty."
+        try:
+            prompt = (
+                "Summarize the following notes in a concise paragraph:"\
+                f"\n{facts}"
+            )
+            resp = openai.ChatCompletion.create(
+                model="gpt-4o",
+                messages=[{"role": "user", "content": prompt}],
+            )
+            summary = resp.choices[0].message["content"].strip()
+            return f"{self.name}: {summary}"
+        except Exception as e:
+            return f"{self.name}: Failed to summarize memory:\n{e}"
 
     def _save_code(self, filename):
         if not self.last_code:

--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@
 
 This is the base of a fully interactive coding bot. Expand with AI core or Discord input.
 
+### Memory Tools
+Use `remember:your fact` to store a memory and `recall` to read them back. The command `summarize` or the **Summarize Memory** button in the browser returns a short summary of everything remembered.
+
 ### ChatGPT Integration
 Hecate can now send your text prompts to OpenAI's ChatGPT. It uses the `gpt-4o`
 model for generating replies. By default it looks
@@ -34,6 +37,7 @@ python "OK workspaces/main. py"
 ```
 
 In the browser interface, type your message into the text box or use the voice button.
+You can also click **Summarize Memory** to get a short summary of all remembered facts.
 
 ### Gmail Integration
 Set the following environment variables so Hecate can send and receive email via Gmail:

--- a/index.html
+++ b/index.html
@@ -13,6 +13,7 @@
   <input type="text" id="emailInput" placeholder="Email address" />
   <button onclick="getLocation()">📍 Get Location</button>
   <button onclick="emailLocation()">Email Location</button>
+  <button onclick="summarizeMemory()">Summarize Memory</button>
   <p><strong>Hecate:</strong> <span id="response"></span></p>
 
   <script>
@@ -81,6 +82,18 @@
       method: "POST",
       headers: {"Content-Type": "application/json"},
       body: JSON.stringify({ message })
+    });
+    const data = await res.json();
+    const reply = data.reply;
+    document.getElementById("response").innerText = reply;
+    speak(reply);
+  }
+
+  async function summarizeMemory() {
+    const res = await fetch("http://localhost:8080/talk", {
+      method: "POST",
+      headers: {"Content-Type": "application/json"},
+      body: JSON.stringify({ message: "summarize" })
     });
     const data = await res.json();
     const reply = data.reply;


### PR DESCRIPTION
## Summary
- add new `summarize` command and implementation in Hecate
- expose summarization in the web UI with a new button
- document memory tools

## Testing
- `python -m py_compile 'OK workspaces/hecate.py'`
- `node --check hecate-auto.js`


------
https://chatgpt.com/codex/tasks/task_e_6887a4632c60832fb327efe9d67af8ef