### PR TITLE
Add entry point for running from zip

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,3 +73,18 @@ Use `move:src|dest` to move or rename files within the `scripts/` folder.
 ### Location Tagging
 Capture your current browser location and email it using the command format `location:lat|lon|recipient`.
 The web interface provides buttons to fetch your coordinates and send them via email.
+
+### Running from a zipped archive
+You can bundle Hecate into a single executable zip using Python's `zipapp` module. First make sure `__main__.py` is present (it runs the server). Create the archive:
+
+```bash
+python -m zipapp . -p '/usr/bin/env python3' -o hecate.pyz
+```
+
+Run it with:
+
+```bash
+python hecate.pyz
+```
+
+This will start the API server directly from the zip file.

--- a/__main__.py
+++ b/__main__.py
@@ -1,0 +1,10 @@
+import os
+import runpy
+
+def main():
+    current_dir = os.path.dirname(__file__)
+    script = os.path.join(current_dir, "OK workspaces", "main.py")
+    runpy.run_path(script, run_name="__main__")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- allow running Hecate as a zip archive
- document building and running a zipapp

## Testing
- `python -m py_compile __main__.py 'OK workspaces/main.py' 'OK workspaces/hecate.py'`


------
https://chatgpt.com/codex/tasks/task_e_6887a6af7f04832f98db72a0b7f59a16