### PR TITLE
Add background option for Hecate front end

### DIFF
--- a/OK workspaces/main.py
+++ b/OK workspaces/main.py
@@ -1,12 +1,21 @@
 from flask import Flask, request, jsonify
 from flask_cors import CORS
 from hecate import Hecate
+import argparse
+import subprocess
+import sys
+import os
 
 app = Flask(__name__)
 CORS(app)
 
 # Instantiate Hecate
 hecate = Hecate()
+
+
+def run_server():
+    """Start the Flask API server."""
+    app.run(host="0.0.0.0", port=8080)
 
 @app.route("/talk", methods=["POST"])
 def talk():
@@ -16,4 +25,25 @@ def talk():
     return jsonify({"reply": response})
 
 if __name__ == "__main__":
-    app.run(host="0.0.0.0", port=8080)
+    parser = argparse.ArgumentParser(description="Hecate API server")
+    parser.add_argument(
+        "-b",
+        "--background",
+        action="store_true",
+        help="Run the front end API server in the background",
+    )
+    args = parser.parse_args()
+
+    if args.background:
+        # Relaunch this script detached from the current session
+        cmd = [sys.executable, os.path.abspath(__file__)]
+        subprocess.Popen(
+            cmd,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            stdin=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+        print("Server started in background")
+    else:
+        run_server()

--- a/README.md
+++ b/README.md
@@ -47,10 +47,11 @@ You can also click **Summarize Memory** to get a short summary of all remembered
    pip install -r requirements.txt
    ```
 
-2. Start the local API server:
+2. Start the local API server (add `-b` to run in the background):
 
    ```bash
-   python "OK workspaces/main.py"
+   python "OK workspaces/main.py"    # foreground
+   python "OK workspaces/main.py" -b # background
    ```
 
 3. Open `index.html` in your browser. The page will communicate with the server running on `localhost:8080`.


### PR DESCRIPTION
## Summary
- allow `main.py` to run as a detached background process
- document background mode in README

## Testing
- `pip install -r requirements.txt`
- `python 'OK workspaces/main.py' -b`

------
https://chatgpt.com/codex/tasks/task_e_6887afd0e990832f822cd3c8f61988c2