### PR TITLE
Clear input field after sending message

### DIFF
--- a/index.html
+++ b/index.html
@@ -102,8 +102,11 @@
   }
 
     async function sendText() {
-      const text = document.getElementById("textInput").value;
+      const inputEl = document.getElementById("textInput");
+      const text = inputEl.value;
       if (!text) return;
+      inputEl.value = "";
+      inputEl.focus();
       document.getElementById("transcript").innerText = `You: ${text}`;
 
       const res = await fetch("http://localhost:8080/talk", {


### PR DESCRIPTION
## Summary
- reset and focus the input box in `sendText` after submitting text

## Testing
- `git ls-files '*.py' -z | xargs -0 python -m py_compile`
- `node --check ai_core.js`
- `node --check hecate-auto.js`


------
https://chatgpt.com/codex/tasks/task_e_6887b3f26514832f80743505bed6d737