### PR TITLE
Add CLI support for text conversation

### DIFF
--- a/OK workspaces/cli.py
+++ b/OK workspaces/cli.py
@@ -1,0 +1,22 @@
+from hecate import Hecate
+
+
+def main():
+    bot = Hecate()
+    print("Type your message. Enter 'quit' to exit.")
+    while True:
+        try:
+            user_input = input('You: ').strip()
+        except (EOFError, KeyboardInterrupt):
+            print()
+            break
+        if not user_input:
+            continue
+        if user_input.lower() in {'quit', 'exit'}:
+            break
+        reply = bot.respond(user_input)
+        print(reply)
+
+
+if __name__ == '__main__':
+    main()

--- a/README.md
+++ b/README.md
@@ -56,6 +56,15 @@ You can also click **Summarize Memory** to get a short summary of all remembered
 
 3. Open `index.html` in your browser. The page will communicate with the server running on `localhost:8080`.
 
+### Command Line Chat
+If you prefer to talk to Hecate directly in your terminal, run the small CLI utility:
+
+```bash
+python "OK workspaces/cli.py"
+```
+
+Type your message and press Enter to receive a response. Use `quit` or `exit` to leave the session.
+
 ### Gmail Integration
 Set the following environment variables so Hecate can send and receive email via Gmail:
 


### PR DESCRIPTION
## Summary
- create a small CLI utility so Hecate can respond to typed input
- document how to run the CLI in the README

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile "OK workspaces/cli.py" "OK workspaces/main.py" "OK workspaces/hecate.py" __main__.py`


------
https://chatgpt.com/codex/tasks/task_e_6887b40d0264832f83fbc7182e9434fe