### PR TITLE
Add selectable reply voice

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ python "OK workspaces/main.py"
 ```
 
 In the browser interface, type your message into the text box or use the voice button.
+Choose a voice from the dropdown labeled "Voice" to hear Hecate reply aloud.
 You can also click **Summarize Memory** to get a short summary of all remembered facts.
 
 ### Run Locally

--- a/index.html
+++ b/index.html
@@ -18,8 +18,11 @@
 <body>
   <h1>🕯️ Talk to Hecate</h1>
   <button onclick="startListening()">🎤 Speak</button>
+  <label for="voiceSelect">Voice:</label>
+  <select id="voiceSelect"></select>
   <input type="text" id="textInput" placeholder="Type your message"/>
   <button onclick="sendText()">Send</button>
+  <div id="log" style="white-space: pre-line; margin-bottom: 1em;"></div>
   <p id="transcript"></p>
   <p id="location"></p>
     <input type="text" id="emailInput" placeholder="Email address" />
@@ -38,6 +41,8 @@
       recognition.onresult = async function(event) {
         const text = event.results[0][0].transcript;
         document.getElementById("transcript").innerText = `You: ${text}`;
+        const logEl = document.getElementById("log");
+        logEl.innerText += `You: ${text}\n`;
 
         const res = await fetch("http://localhost:8080/talk", {
           method: "POST",
@@ -48,6 +53,7 @@
         const data = await res.json();
         const reply = data.reply;
         document.getElementById("response").innerText = reply;
+        logEl.innerText += `${reply}\n`;
         speak(reply);
       };
 
@@ -62,8 +68,28 @@
     const msg = new SpeechSynthesisUtterance();
     msg.text = text;
     msg.lang = "en-US";
+    const voiceName = document.getElementById("voiceSelect").value;
+    const voice = window.speechSynthesis.getVoices().find(v => v.name === voiceName);
+    if (voice) msg.voice = voice;
     window.speechSynthesis.speak(msg);
   }
+
+  function populateVoices() {
+    const select = document.getElementById("voiceSelect");
+    const voices = window.speechSynthesis.getVoices();
+    select.innerHTML = "";
+    voices.forEach(v => {
+      const opt = document.createElement("option");
+      opt.value = v.name;
+      opt.textContent = v.name;
+      select.appendChild(opt);
+    });
+    const preferred = voices.find(v => /hecate/i.test(v.name)) || voices.find(v => /female/i.test(v.name));
+    if (preferred) select.value = preferred.name;
+  }
+
+  window.speechSynthesis.onvoiceschanged = populateVoices;
+  populateVoices();
 
   let currentLocation = null;
   function getLocation() {
@@ -121,6 +147,8 @@
       inputEl.value = "";
       inputEl.focus();
       document.getElementById("transcript").innerText = `You: ${text}`;
+      const logEl = document.getElementById("log");
+      logEl.innerText += `You: ${text}\n`;
 
       const res = await fetch("http://localhost:8080/talk", {
         method: "POST",
@@ -131,6 +159,7 @@
       const data = await res.json();
       const reply = data.reply;
       document.getElementById("response").innerText = reply;
+      logEl.innerText += `${reply}\n`;
       speak(reply);
     }
 


### PR DESCRIPTION
## Summary
- expose a dropdown with available voice options
- use selected voice for replies while preserving conversation log in the UI
- label the voice dropdown and document the label in README

## Testing
- `git ls-files '*.py' | xargs -d '\n' python -m py_compile`
- `node -c hecate-auto.js`


------
https://chatgpt.com/codex/tasks/task_e_6887be251418832f86ed2ad4b03592ec