### PR TITLE
Add 3D background text with spinning glyph

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,8 +2,57 @@
 <html>
 <head>
   <title>Hecate — Voice Assistant</title>
+  <style>
+    html, body {
+      background: #000;
+      color: #fff;
+      min-height: 100vh;
+      margin: 0;
+      font-family: sans-serif;
+    }
+    body {
+      padding: 2em;
+      overflow: hidden;
+      perspective: 800px;
+      transform-style: preserve-3d;
+    }
+
+    #background-glyph {
+      position: fixed;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      font-size: 200px;
+      color: rgba(255, 255, 255, 0.08);
+      animation: spin 20s linear infinite;
+      user-select: none;
+      pointer-events: none;
+      z-index: 0;
+    }
+
+    #hecate-logo {
+      position: fixed;
+      top: 25%;
+      left: 50%;
+      transform: translateX(-50%) translateZ(40px) rotateX(20deg);
+      font-size: 72px;
+      font-weight: bold;
+      color: #fff;
+      text-shadow: 0 0 15px rgba(255, 255, 255, 0.8);
+      user-select: none;
+      pointer-events: none;
+      z-index: 1;
+    }
+
+    @keyframes spin {
+      from { transform: translate(-50%, -50%) rotateY(0deg); }
+      to { transform: translate(-50%, -50%) rotateY(360deg); }
+    }
+  </style>
 </head>
-<body style="font-family: sans-serif; padding: 2em;">
+<body>
+  <div id="background-glyph">✦</div>
+  <div id="hecate-logo">Hecate</div>
   <h1>🕯️ Talk to Hecate</h1>
   <button onclick="startListening()">🎤 Speak</button>
   <input type="text" id="textInput" placeholder="Type your message"/>


### PR DESCRIPTION
## Summary
- keep existing dark theme while adding 3D styling
- spin a faint background glyph
- render the "Hecate" label in large white 3D text

## Testing
- `pip install -q -r requirements.txt`
- `git ls-files '*.py' | xargs -I{} python -m py_compile {}`
- `node --check hecate-auto.js`
- `node --check ai_core.js`


------
https://chatgpt.com/codex/tasks/task_e_6887b4c70564832fb468e8e0b4650134