### PR TITLE
Implement file deletion command

### DIFF
--- a/OK workspaces/hecate.py
+++ b/OK workspaces/hecate.py
@@ -77,6 +77,10 @@ class Hecate:
             except Exception:
                 return f"{self.name}: Use 'create:filename|content'"
 
+        elif user_input.startswith("delete:"):
+            filename = user_input.split("delete:", 1)[1].strip()
+            return self._delete_file(filename)
+
         elif user_input.startswith("search:"):
             query = user_input.split("search:", 1)[1].strip()
             return self._search_web(query)
@@ -168,6 +172,20 @@ class Hecate:
             return f"{self.name}: Created file {filename}."
         except Exception as e:
             return f"{self.name}: Failed to create file:\n{e}"
+
+    def _delete_file(self, filename):
+        """Remove a file from the scripts folder."""
+        scripts_dir = os.path.abspath("scripts")
+        path = os.path.abspath(os.path.join(scripts_dir, filename))
+        if not path.startswith(scripts_dir + os.sep):
+            return f"{self.name}: Invalid filename."
+        if not os.path.isfile(path):
+            return f"{self.name}: I couldn't find a file named {filename}."
+        try:
+            os.remove(path)
+            return f"{self.name}: Deleted {filename}."
+        except Exception as e:
+            return f"{self.name}: Failed to delete file:\n{e}"
 
     def _run_code(self, code):
         buffer = io.StringIO()

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ Use the commands `email:recipient|subject|body` to send an email and `inbox:n` t
 ### File Utilities
 Use `retrieve:url|filename` to download a remote file into the `scripts/` folder.
 Use `create:filename|content` to create a file with optional content.
+Use `delete:filename` to remove a file from the `scripts/` folder. Only regular
+files can be removed, and any path outside that folder will be rejected.
 
 ### Location Tagging
 Capture your current browser location and email it using the command format `location:lat|lon|recipient`.


### PR DESCRIPTION
## Summary
- add `delete:filename` command to hecate parser
- implement `_delete_file` with path validation
- document file deletion in README
- ensure only regular files are deletable

## Testing
- `python -m py_compile 'OK workspaces/hecate.py' 'OK workspaces/main. py'`

------
https://chatgpt.com/codex/tasks/task_e_6887592be5b8832f8a9f3b429a4fee8f