### PR TITLE
Enable CLI text-to-speech

### DIFF
--- a/OK workspaces/cli.py
+++ b/OK workspaces/cli.py
@@ -1,9 +1,16 @@
 from hecate import Hecate
 import argparse
 import speech_recognition as sr
+import subprocess
+
+def speak(text):
+    try:
+        subprocess.run(["espeak", text], check=True)
+    except Exception:
+        pass
 
 
-def voice_chat(bot):
+def voice_chat(bot, speak_output=False):
     """Continuous microphone input loop."""
     r = sr.Recognizer()
     mic = sr.Microphone()
@@ -20,12 +27,14 @@ def voice_chat(bot):
             print(f'You: {text}')
             reply = bot.respond(text)
             print(reply)
+            if speak_output:
+                speak(reply)
         except KeyboardInterrupt:
             print()
             break
 
 
-def text_chat(bot):
+def text_chat(bot, speak_output=False):
     print("Type your message. Enter 'quit' to exit.")
     while True:
         try:
@@ -39,15 +48,18 @@ def text_chat(bot):
             break
         reply = bot.respond(user_input)
         print(reply)
+        if speak_output:
+            speak(reply)
 
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description="Hecate CLI")
     parser.add_argument("--voice", action="store_true", help="Use microphone input")
+    parser.add_argument("--speak", action="store_true", help="Speak responses aloud")
     args = parser.parse_args()
 
     bot = Hecate()
     if args.voice:
-        voice_chat(bot)
+        voice_chat(bot, speak_output=args.speak)
     else:
-        text_chat(bot)
+        text_chat(bot, speak_output=args.speak)

--- a/README.md
+++ b/README.md
@@ -71,6 +71,12 @@ You can also enable speech-to-text input with the `--voice` flag (requires a mic
 python "OK workspaces/cli.py" --voice
 ```
 
+To hear the responses spoken aloud, add the `--speak` flag (requires pyttsx3):
+
+```bash
+python "OK workspaces/cli.py" --speak
+```
+
 ### Gmail Integration
 Set the following environment variables so Hecate can send and receive email via Gmail:
 


### PR DESCRIPTION
## Summary
- add new `--speak` flag for CLI speech output
- use `espeak` command to read replies aloud
- document CLI speech flag in README

## Testing
- `python -m py_compile 'OK workspaces/cli.py'`
- `pip install -q -r requirements.txt`

------
https://chatgpt.com/codex/tasks/task_e_6887c59a6dd4832f8ee5478df6f728bf