### PR TITLE
Fix automatic geolocation trigger

### DIFF
--- a/index.html
+++ b/index.html
@@ -199,6 +199,8 @@
     function exitWindow() {
       window.close();
     }
+    // Automatically request location once the page has loaded
+    getLocation();
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- ensure the web interface automatically obtains location by calling `getLocation()` once the page loads

## Testing
- `python -m py_compile "__main__.py" "OK workspaces/main.py" "OK workspaces/cli.py" "OK workspaces/hecate.py"`


------
https://chatgpt.com/codex/tasks/task_e_6887c1ca9ec8832f8659a41457df9c1b