### PR TITLE
Implement cognitive learning feature

### DIFF
--- a/OK workspaces/hecate.py
+++ b/OK workspaces/hecate.py
@@ -127,6 +127,10 @@ class Hecate:
             except Exception:
                 return f"{self.name}: Use 'location:lat|lon|email'"
 
+        elif user_input.startswith("learn:"):
+            content = user_input.split("learn:", 1)[1].strip()
+            return self._learn_from_text(content)
+
         elif any(p in user_input.lower() for p in self.distress_phrases) or "alika in distress" in user_input.lower():
             to = os.getenv("DISTRESS_EMAIL")
             if not self.current_location:
@@ -184,6 +188,26 @@ class Hecate:
             return f"{self.name}: {summary}"
         except Exception as e:
             return f"{self.name}: Failed to summarize memory:\n{e}"
+
+    def _learn_from_text(self, content):
+        """Generate key takeaways from text and store them in memory."""
+        if not content:
+            return f"{self.name}: No text provided to learn from."
+        try:
+            prompt = (
+                "Extract the key lessons or facts from the following text in short bullet points:"\
+                f"\n{content}"
+            )
+            resp = openai.ChatCompletion.create(
+                model="gpt-4o",
+                messages=[{"role": "user", "content": prompt}],
+            )
+            summary = resp.choices[0].message["content"].strip()
+            with open(self.memory_file, "a") as f:
+                f.write(summary + "\n")
+            return f"{self.name}: I've noted the key points."
+        except Exception as e:
+            return f"{self.name}: Failed to learn from text:\n{e}"
 
     def _save_code(self, filename):
         if not self.last_code:

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ This is the base of a fully interactive coding bot. Expand with AI core or Disco
 
 ### Memory Tools
 Use `remember:your fact` to store a memory and `recall` to read them back. The command `summarize` or the **Summarize Memory** button in the browser returns a short summary of everything remembered.
+Use `learn:some text` to extract key bullet points from the provided content and append them to memory.
 
 ### ChatGPT Integration
 Hecate can now send your text prompts to OpenAI's ChatGPT. It uses the `gpt-4o`


### PR DESCRIPTION
## Summary
- allow Hecate to learn from provided text via a new `learn:` command
- note the new command in the README documentation

## Testing
- `python -m py_compile OK\ workspaces/*.py`


------
https://chatgpt.com/codex/tasks/task_e_6887c60d5ce0832f81ebe5cf85287ef2