### PR TITLE
Add conversation logging

### DIFF
--- a/OK workspaces/main.py
+++ b/OK workspaces/main.py
@@ -23,6 +23,12 @@ def talk():
     data = request.json
     user_input = data.get("message", "")
     response = hecate.respond(user_input)
+    try:
+        with open("conversation.log", "a") as log:
+            log.write(f"User: {user_input}\n")
+            log.write(f"Hecate: {response}\n")
+    except Exception:
+        pass
     return jsonify({"reply": response})
 
 

--- a/README.md
+++ b/README.md
@@ -51,9 +51,11 @@ You can also click **Summarize Memory** to get a short summary of all remembered
 2. Start the local API server (add `-b` to run in the background):
 
    ```bash
-   python "OK workspaces/main.py"    # foreground
-   python "OK workspaces/main.py" -b # background
-   ```
+  python "OK workspaces/main.py"    # foreground
+  python "OK workspaces/main.py" -b # background
+  ```
+
+   The server logs each conversation to `conversation.log` so you can read back the dialogue later.
 
 3. Open `index.html` in your browser. The page will communicate with the server running on `localhost:8080`.
 


### PR DESCRIPTION
## Summary
- log user and bot text to `conversation.log`
- document the conversation log in README

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6887c5f1b9b8832fa1d6076de742efcf