### PR TITLE
Allow custom GPT model

### DIFF
--- a/OK workspaces/hecate.py
+++ b/OK workspaces/hecate.py
@@ -9,6 +9,9 @@ import email
 from email.mime.text import MIMEText
 import openai
 
+# Allow overriding the OpenAI model via environment variable. Default to gpt-4o
+OPENAI_MODEL = os.getenv("OPENAI_MODEL", "gpt-4o")
+
 
 def _load_openai_key():
     """Fetch the OpenAI API key from env or local file."""
@@ -192,7 +195,7 @@ class Hecate:
                 f"\n{facts}"
             )
             resp = openai.ChatCompletion.create(
-                model="gpt-4o",
+                model=OPENAI_MODEL,
                 messages=[{"role": "user", "content": prompt}],
             )
             summary = resp.choices[0].message["content"].strip()
@@ -210,7 +213,7 @@ class Hecate:
                 f"\n{content}"
             )
             resp = openai.ChatCompletion.create(
-                model="gpt-4o",
+                model=OPENAI_MODEL,
                 messages=[{"role": "user", "content": prompt}],
             )
             summary = resp.choices[0].message["content"].strip()
@@ -380,7 +383,7 @@ class Hecate:
     def _chatgpt_response(self, text):
         try:
             resp = openai.ChatCompletion.create(
-                model="gpt-4o",
+                model=OPENAI_MODEL,
                 messages=[{"role": "user", "content": text}]
             )
             answer = resp.choices[0].message["content"].strip()

--- a/README.md
+++ b/README.md
@@ -21,8 +21,9 @@ Use `remember:your fact` to store a memory and `recall` to read them back. The c
 Use `learn:some text` to extract key bullet points from the provided content and append them to memory.
 
 ### ChatGPT Integration
-Hecate can now send your text prompts to OpenAI's ChatGPT. It uses the `gpt-4o`
-model for generating replies. By default it looks
+Hecate can now send your text prompts to OpenAI's ChatGPT. By default it uses
+the `gpt-4o` model, but you can select any available GPT model by setting the
+`OPENAI_MODEL` environment variable. The script looks
 for the API key in the `OPENAI_API_KEY` environment variable. If that isn't
 present, it will attempt to load a key from a file named `openai_key.txt` in the
 repository root.
@@ -30,6 +31,8 @@ repository root.
 ```bash
 # Option 1: environment variable
 export OPENAI_API_KEY=your_api_key
+# Optional: choose a specific model
+export OPENAI_MODEL=gpt-3.5-turbo
 
 # Option 2: place the key in openai_key.txt
 echo your_api_key > openai_key.txt


### PR DESCRIPTION
## Summary
- let the `Hecate` Python helper pick which GPT model to use via `OPENAI_MODEL`
- document how to set `OPENAI_MODEL`

## Testing
- `python - <<'PY'
import subprocess, shlex, sys
import os
files = subprocess.check_output(['git', 'ls-files', '*.py']).decode().splitlines()
for f in files:
    print('compile', f)
    compile(open(f, 'r').read(), f, 'exec')
print('done')
PY`

------
https://chatgpt.com/codex/tasks/task_e_6887c7f0a8c0832f8c5b4c3722d7814c