### PR TITLE
Add startup identity prompt

### DIFF
--- a/OK workspaces/cli.py
+++ b/OK workspaces/cli.py
@@ -59,6 +59,11 @@ if __name__ == '__main__':
     args = parser.parse_args()
 
     bot = Hecate()
+    intro = bot.startup_message()
+    if intro:
+        print(intro)
+        if args.speak:
+            speak(intro)
     if args.voice:
         voice_chat(bot, speak_output=args.speak)
     else:

--- a/OK workspaces/hecate.py
+++ b/OK workspaces/hecate.py
@@ -39,6 +39,8 @@ class Hecate:
         self.gmail_user = os.getenv("GMAIL_USER")
         self.gmail_pass = os.getenv("GMAIL_PASS")
         self.current_location = None
+        self.user_name = None
+        self._asked_identity = False
         self.distress_phrases = [
             "help",
             "help me",
@@ -50,7 +52,25 @@ class Hecate:
             "leave me alone",
         ]
 
+    def startup_message(self):
+        """Return the initial prompt asking for the user's identity."""
+        if not self._asked_identity:
+            self._asked_identity = True
+            return f"{self.name}: Who are you?"
+        return None
+
     def respond(self, user_input):
+        if not self._asked_identity:
+            # If startup_message was never retrieved, ask for user's identity now
+            self._asked_identity = True
+            return f"{self.name}: Who are you?"
+
+        if self.user_name is None:
+            # Treat the first user response as their name
+            self.user_name = user_input.strip() or None
+            if self.user_name:
+                return f"{self.name}: Nice to meet you, {self.user_name}."
+
         if user_input.startswith("remember:"):
             fact = user_input.split("remember:", 1)[1].strip()
             return self._remember_fact(fact)

--- a/index.html
+++ b/index.html
@@ -199,7 +199,25 @@
     function exitWindow() {
       window.close();
     }
-    window.addEventListener('DOMContentLoaded', getLocation);
+    window.addEventListener('DOMContentLoaded', () => {
+      getLocation();
+      fetch('http://localhost:8080/talk', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ message: '' })
+      })
+      .then(res => res.json())
+      .then(data => {
+        const intro = data.reply;
+        document.getElementById("response").innerText = intro;
+        speak(intro);
+      })
+      .catch(() => {
+        const intro = 'Hecate: Who are you?';
+        document.getElementById("response").innerText = intro;
+        speak(intro);
+      });
+    });
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- prompt the user for their identity on startup
- store and greet the provided name
- trigger startup prompt in CLI and web UI

## Testing
- `python -m py_compile __main__.py 'OK workspaces/main.py' 'OK workspaces/cli.py' 'OK workspaces/hecate.py'`

------
https://chatgpt.com/codex/tasks/task_e_6887c7709a58832f9229b25690a80f4a