### PR TITLE
Enable clone communication and shared memory

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ This is the base of a fully interactive coding bot. Expand with AI core or Disco
 ### Memory Tools
 Use `remember:your fact` to store a memory and `recall` to read them back. The command `summarize` or the **Summarize Memory** button in the browser returns a short summary of everything remembered.
 Use `learn:some text` to extract key bullet points from the provided content and append them to memory.
+Use `clone:send:message` to broadcast a message to other running clones. They can read all messages with `clone:read`.
+Use `clone:remember:fact` to store a note in a shared memory file that all clones access. Retrieve the combined notes with `clone:memories`.
 
 ### ChatGPT Integration
 Hecate can now send your text prompts to OpenAI's ChatGPT. It uses the `gpt-4o`


### PR DESCRIPTION
## Summary
- allow clones to communicate using shared log files
- record clone-wide memory using a common shared log
- document clone communication commands in the README

## Testing
- `python -m py_compile 'OK workspaces/hecate.py'`
- `python -m py_compile '__main__.py' 'OK workspaces/main.py' 'OK workspaces/cli.py'`
- `python 'OK workspaces/cli.py' -h`

------
https://chatgpt.com/codex/tasks/task_e_6887c7b114a8832f9403f83b3f72a4ee