### PR TITLE
Center transcript on screen

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,6 +15,7 @@
       display: flex;
       flex-direction: column;
       align-items: center;
+      justify-content: center;
     }
 
     input[type="text"] {
@@ -22,6 +23,11 @@
       margin: 1em auto;
       width: 80%;
       max-width: 400px;
+    }
+    #transcript {
+      text-align: center;
+      font-size: 1.5em;
+      margin-top: 1em;
     }
   </style>
 </head>


### PR DESCRIPTION
## Summary
- center the layout vertically so controls are in the middle of the page
- style the transcript text to appear centered and larger

## Testing
- `find . -name '*.py' -print0 | xargs -0 python -m py_compile`

------
https://chatgpt.com/codex/tasks/task_e_6887c81eed78832fa46a3016ee698507