### PR TITLE
Add excess compute sharing script

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ Use `clone:send:message` to broadcast a message to other running clones. They ca
 Use `clone:remember:fact` to store a note in a shared memory file that all clones access. Retrieve the combined notes with `clone:memories`.
 To sync clones over a network, start `clone_network.py` on one machine and set the environment variable `CLONE_SERVER_URL` on each clone to point at that server (e.g. `http://host:5000`). When defined, clone commands will use the server instead of local files.
 
+### Excess Compute Sharing
+Run `excess_compute.py` on each clone to contribute idle CPU time back to the cluster. The script checks local CPU usage and only requests tasks from the server when below the `CPU_THRESHOLD` (default 50%). Set `CLONE_SERVER_URL` to the running `clone_network.py` instance and queue tasks via the `/task` endpoint.
+
+
 ### ChatGPT Integration
 Hecate can now send your text prompts to OpenAI's ChatGPT. By default it uses
 the `gpt-4o` model, but you can select any available GPT model by setting the

--- a/clone_network.py
+++ b/clone_network.py
@@ -7,6 +7,8 @@ CORS(app)
 
 messages = []
 memories = []
+tasks = []
+results = []
 
 @app.route('/send', methods=['POST'])
 def send_message():
@@ -35,6 +37,32 @@ def remember_fact():
 @app.route('/memories', methods=['GET'])
 def get_memories():
     return '\n'.join(memories)
+
+@app.route('/task', methods=['POST'])
+def add_task():
+    data = request.get_json(force=True)
+    task = data.get('task')
+    if task:
+        tasks.append(task)
+        return jsonify({'status': 'queued'})
+    return jsonify({'error': 'missing task'}), 400
+
+@app.route('/task/assign', methods=['GET'])
+def assign_task():
+    if tasks:
+        task = tasks.pop(0)
+        return jsonify({'task': task})
+    return jsonify({'task': None})
+
+@app.route('/task/result', methods=['POST'])
+def store_result():
+    data = request.get_json(force=True)
+    result = data.get('result')
+    clone_id = data.get('id', 'unknown')
+    if result is not None:
+        results.append(f"{clone_id}: {result}")
+        return jsonify({'status': 'stored'})
+    return jsonify({'error': 'missing result'}), 400
 
 if __name__ == '__main__':
     port = int(os.getenv('CLONE_PORT', '5000'))

--- a/excess_compute.py
+++ b/excess_compute.py
@@ -1,0 +1,46 @@
+import os
+import time
+import subprocess
+import requests
+import psutil
+
+SERVER_URL = os.getenv('CLONE_SERVER_URL', 'http://localhost:5000')
+CLONE_ID = os.getenv('CLONE_ID', os.uname().nodename)
+CPU_THRESHOLD = float(os.getenv('CPU_THRESHOLD', '50'))
+CHECK_INTERVAL = float(os.getenv('CHECK_INTERVAL', '10'))
+
+
+def fetch_task():
+    try:
+        resp = requests.get(f"{SERVER_URL}/task/assign", params={'id': CLONE_ID}, timeout=5)
+        if resp.ok:
+            data = resp.json()
+            return data.get('task')
+    except Exception as e:
+        print(f"error fetching task: {e}")
+    return None
+
+
+def report_result(result):
+    try:
+        requests.post(f"{SERVER_URL}/task/result", json={'id': CLONE_ID, 'result': result}, timeout=5)
+    except Exception as e:
+        print(f"error reporting result: {e}")
+
+
+def main():
+    while True:
+        cpu = psutil.cpu_percent(interval=1)
+        if cpu < CPU_THRESHOLD:
+            task = fetch_task()
+            if task:
+                try:
+                    output = subprocess.check_output(task, shell=True, text=True, timeout=60)
+                except subprocess.CalledProcessError as e:
+                    output = e.output
+                report_result(output)
+        time.sleep(CHECK_INTERVAL)
+
+
+if __name__ == '__main__':
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ beautifulsoup4
 openai
 SpeechRecognition
 PyAudio
+psutil


### PR DESCRIPTION
## Summary
- add `excess_compute.py` for donating unused CPU cycles
- extend `clone_network.py` with a simple task queue API
- document new feature in README
- update requirements to include `psutil`

## Testing
- `python -m py_compile clone_network.py excess_compute.py 'OK workspaces/hecate.py' 'OK workspaces/cli.py' 'OK workspaces/main.py'`
- `pip install -r requirements.txt` *(fails: PyAudio build error)*

------
https://chatgpt.com/codex/tasks/task_e_6887cb61e2b8832f96a7feb43bc33b9c