### PR TITLE
Add health check endpoints

### DIFF
--- a/OK workspaces/main.py
+++ b/OK workspaces/main.py
@@ -18,6 +18,11 @@ def run_server():
     """Start the Flask API server."""
     app.run(host="0.0.0.0", port=8080)
 
+@app.route("/health", methods=["GET"])
+def health():
+    """Simple health check endpoint."""
+    return jsonify({"status": "ok"})
+
 @app.route("/talk", methods=["POST"])
 def talk():
     data = request.json

--- a/README.md
+++ b/README.md
@@ -90,6 +90,9 @@ Both the CLI tools and the API server automatically read the key from these loca
 
    The server logs each conversation to `conversation.log` so you can read back the dialogue later.
 
+   A health check endpoint is available at `http://localhost:8080/health`.
+   Load balancers can poll this URL to verify the service is running.
+
 3. Open `index.html` in your browser. The page will communicate with the server running on `localhost:8080`.
 
 ### Command Line Chat

--- a/clone_network.py
+++ b/clone_network.py
@@ -10,6 +10,11 @@ memories = []
 tasks = []
 results = []
 
+@app.route('/health', methods=['GET'])
+def health():
+    """Simple health check endpoint."""
+    return jsonify({'status': 'ok'})
+
 @app.route('/send', methods=['POST'])
 def send_message():
     data = request.get_json(force=True)


### PR DESCRIPTION
## Summary
- expose `/health` endpoint in main API server
- add `/health` to clone network server
- document the health check in the README

## Testing
- `python -m py_compile 'OK workspaces/main.py' clone_network.py`
- `python -m py_compile 'OK workspaces/hecate.py'`
- `flake8 || true`

------
https://chatgpt.com/codex/tasks/task_e_6887cb17d85c832fb525d496f9d757d8