### PR TITLE
Add clone firewall filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@ Use `clone:send:message` to broadcast a message to other running clones. They ca
 Use `clone:remember:fact` to store a note in a shared memory file that all clones access. Retrieve the combined notes with `clone:memories`.
 To sync clones over a network, start `clone_network.py` on one machine and set the environment variable `CLONE_SERVER_URL` on each clone to point at that server (e.g. `http://host:5000`). When defined, clone commands will use the server instead of local files.
 
+### Sensitive Data Firewall
+`clone_network.py` now masks API keys and other tokens from shared messages and tasks. Set `FIREWALL_PATTERNS` with comma-separated regexes to customize what gets filtered.
+
 ### Excess Compute Sharing
 Run `excess_compute.py` on each clone to contribute idle CPU time back to the cluster. The script checks local CPU usage and only requests tasks from the server when below the `CPU_THRESHOLD` (default 50%). Set `CLONE_SERVER_URL` to the running `clone_network.py` instance and queue tasks via the `/task` endpoint.
 

--- a/clone_network.py
+++ b/clone_network.py
@@ -1,6 +1,7 @@
 import os
 from flask import Flask, request, jsonify
 from flask_cors import CORS
+from firewall import sanitize_text
 
 app = Flask(__name__)
 CORS(app)
@@ -16,6 +17,7 @@ def send_message():
     clone_id = data.get('id', 'unknown')
     msg = data.get('message', '')
     if msg:
+        msg = sanitize_text(msg)
         messages.append(f"{clone_id}: {msg}")
         return jsonify({'status': 'ok'})
     return jsonify({'error': 'missing message'}), 400
@@ -30,6 +32,7 @@ def remember_fact():
     clone_id = data.get('id', 'unknown')
     fact = data.get('fact', '')
     if fact:
+        fact = sanitize_text(fact)
         memories.append(f"{clone_id}: {fact}")
         return jsonify({'status': 'ok'})
     return jsonify({'error': 'missing fact'}), 400
@@ -43,6 +46,7 @@ def add_task():
     data = request.get_json(force=True)
     task = data.get('task')
     if task:
+        task = sanitize_text(task)
         tasks.append(task)
         return jsonify({'status': 'queued'})
     return jsonify({'error': 'missing task'}), 400
@@ -60,6 +64,7 @@ def store_result():
     result = data.get('result')
     clone_id = data.get('id', 'unknown')
     if result is not None:
+        result = sanitize_text(str(result))
         results.append(f"{clone_id}: {result}")
         return jsonify({'status': 'stored'})
     return jsonify({'error': 'missing result'}), 400

--- a/firewall.py
+++ b/firewall.py
@@ -1,0 +1,27 @@
+import os
+import re
+
+DEFAULT_PATTERNS = [
+    r"sk-[A-Za-z0-9]{32,}",  # OpenAI style keys
+    r"gh[pous]_[A-Za-z0-9]{36,}",  # GitHub tokens
+    r"api[_-]?key",
+    r"password",
+    r"secret",
+    r"token",
+]
+
+_custom = os.getenv("FIREWALL_PATTERNS")
+if _custom:
+    CUSTOM_PATTERNS = [p.strip() for p in _custom.split(',') if p.strip()]
+    PATTERNS = [re.compile(p, re.IGNORECASE) for p in (CUSTOM_PATTERNS + DEFAULT_PATTERNS)]
+else:
+    PATTERNS = [re.compile(p, re.IGNORECASE) for p in DEFAULT_PATTERNS]
+
+def sanitize_text(text: str) -> str:
+    """Replace sensitive patterns with [BLOCKED]."""
+    if not text:
+        return text
+    result = text
+    for pat in PATTERNS:
+        result = pat.sub("[BLOCKED]", result)
+    return result


### PR DESCRIPTION
## Summary
- add simple pattern-based firewall to sanitize clone messages
- integrate firewall into `clone_network.py`
- document the `FIREWALL_PATTERNS` setting

## Testing
- `python -m py_compile clone_network.py firewall.py`

------
https://chatgpt.com/codex/tasks/task_e_6887cf62fea4832fb0e72601abefc8ae