### PR TITLE
Add database insertion script

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,3 +171,11 @@ Run `antivirus.py` to periodically scan the `scripts/` directory for infected fi
 ### MandemOS Database
 Run `python setup_database.py` to create a SQLite database named `mandemos.db` with tables for scrolls, relics, and keys.
 
+Once the database exists, you can populate it with the metadata from `metadata.json` using `insert_metadata.py`:
+
+```bash
+python insert_metadata.py
+```
+
+This inserts the scroll information from `metadata.json` into the `scrolls` table.
+

--- a/insert_metadata.py
+++ b/insert_metadata.py
@@ -1,0 +1,31 @@
+import sqlite3
+import json
+import os
+from setup_database import DB_NAME, setup_database
+
+METADATA_FILE = 'metadata.json'
+
+def insert_metadata():
+    if not os.path.exists(DB_NAME):
+        setup_database()
+
+    with open(METADATA_FILE, 'r') as f:
+        data = json.load(f)
+
+    name = data.get('name')
+    description = data.get('description')
+    if not (name and description):
+        raise ValueError('metadata.json missing name or description')
+
+    conn = sqlite3.connect(DB_NAME)
+    cur = conn.cursor()
+    cur.execute(
+        'INSERT INTO scrolls (name, description) VALUES (?, ?)',
+        (name, description)
+    )
+    conn.commit()
+    conn.close()
+    print(f"Inserted '{name}' into scrolls table of {DB_NAME}.")
+
+if __name__ == '__main__':
+    insert_metadata()


### PR DESCRIPTION
## Summary
- add `insert_metadata.py` to populate `mandemos.db`
- document how to use the script in README

## Testing
- `python -m py_compile insert_metadata.py setup_database.py`
- `python setup_database.py`
- `python insert_metadata.py`
- `sqlite3 mandemos.db "SELECT * FROM scrolls;"`

------
https://chatgpt.com/codex/tasks/task_e_6887d321098c832f9227d8b0dac10665