### PR TITLE
Require password for admin access

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,9 @@
 ### Server Administration
 Colby Atcheson is the server administrator. Update `server_admins.json` to grant additional admin access.
 
+### Admin Password
+Use `admin:<password>` to gain admin privileges. Check status with `admin:status` and revoke with `admin:logout`. The default password is `whostheboss` or can be overridden with the `ADMIN_PASSWORD` environment variable.
+
 ### Usage
 1. Create a `config.json` file with your GitHub token and remote URL:
    ```json


### PR DESCRIPTION
## Summary
- add admin password configuration in `Hecate`
- store admin status in `admin_status.txt`
- provide commands `admin:<password>`, `admin:status`, and `admin:logout`
- document admin password usage in README

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6887d4afe474832fb6c6173b0dbdd56b