### PR TITLE
Add DB read script

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,5 +169,24 @@ Use `selfrepair:description` to attempt an automated fix of Hecate's own code ba
 Run `antivirus.py` to periodically scan the `scripts/` directory for infected files using `clamscan`. The script also attempts to keep the ClamAV virus definitions up to date by calling `freshclam` at regular intervals. Any detected threats are moved to the `quarantine/` folder. Ensure both `clamscan` and `freshclam` are installed so the scan and updates can run successfully.
 
 ### MandemOS Database
-Run `python setup_database.py` to create a SQLite database named `mandemos.db` with tables for scrolls, relics, and keys.
+Run `python setup_database.py` to create a SQLite database named `mandemos.db` with tables for scrolls, relics, keys, and keyword usage statistics.
+
+After running the clone network, you can capture the current keyword usage by
+executing:
+
+```bash
+python keyword_stats_to_db.py
+```
+
+This script queries the `/keywords` endpoint of the clone network (controlled by
+`CLONE_SERVER_URL`) and updates the `keyword_usage` table with the latest counts.
+If the network cannot be reached, the script simply prints an error and exits without modifying the database.
+
+To inspect the stored keyword statistics, run:
+
+```bash
+python read_keyword_usage.py
+```
+
+This command prints the contents of the `keyword_usage` table so you can verify what each clone has reported.
 

--- a/keyword_stats_to_db.py
+++ b/keyword_stats_to_db.py
@@ -1,0 +1,57 @@
+import os
+import sqlite3
+import requests
+
+DB_NAME = 'mandemos.db'
+SERVER_URL = os.getenv('CLONE_SERVER_URL', 'http://localhost:5000')
+
+
+def init_db():
+    """Ensure the keyword_usage table exists and return connection."""
+    conn = sqlite3.connect(DB_NAME)
+    cur = conn.cursor()
+    cur.execute(
+        '''CREATE TABLE IF NOT EXISTS keyword_usage (
+            clone_id TEXT,
+            keyword TEXT,
+            count INTEGER,
+            PRIMARY KEY (clone_id, keyword)
+        )'''
+    )
+    conn.commit()
+    return conn
+
+
+def fetch_keyword_stats():
+    """Retrieve keyword usage stats from the clone network server."""
+    try:
+        resp = requests.get(f"{SERVER_URL}/keywords", timeout=5)
+        resp.raise_for_status()
+        return resp.json()
+    except requests.RequestException as exc:
+        print(f"Failed to fetch keyword stats: {exc}")
+        return {}
+
+
+def store_stats(conn, stats):
+    cur = conn.cursor()
+    for clone_id, keywords in stats.items():
+        for kw, count in keywords.items():
+            cur.execute(
+                'INSERT OR REPLACE INTO keyword_usage (clone_id, keyword, count) VALUES (?, ?, ?)',
+                (clone_id, kw, count)
+            )
+    conn.commit()
+
+
+def main():
+    conn = init_db()
+    stats = fetch_keyword_stats()
+    if stats:
+        store_stats(conn, stats)
+        print('Keyword usage stored to database')
+    conn.close()
+
+
+if __name__ == '__main__':
+    main()

--- a/read_keyword_usage.py
+++ b/read_keyword_usage.py
@@ -1,0 +1,21 @@
+import sqlite3
+
+DB_NAME = 'mandemos.db'
+
+
+def read_keyword_usage():
+    """Print all keyword usage statistics stored in the database."""
+    conn = sqlite3.connect(DB_NAME)
+    cur = conn.cursor()
+    cur.execute('SELECT clone_id, keyword, count FROM keyword_usage ORDER BY clone_id, keyword')
+    rows = cur.fetchall()
+    if not rows:
+        print('No keyword usage data found.')
+    else:
+        for clone_id, keyword, count in rows:
+            print(f"{clone_id} - {keyword}: {count}")
+    conn.close()
+
+
+if __name__ == '__main__':
+    read_keyword_usage()

--- a/setup_database.py
+++ b/setup_database.py
@@ -7,7 +7,8 @@ DB_NAME = 'mandemos.db'
 TABLES = {
     'scrolls': 'CREATE TABLE IF NOT EXISTS scrolls (id INTEGER PRIMARY KEY, name TEXT, description TEXT)',
     'relics': 'CREATE TABLE IF NOT EXISTS relics (id INTEGER PRIMARY KEY, name TEXT, origin TEXT)',
-    'keys': 'CREATE TABLE IF NOT EXISTS keys (id INTEGER PRIMARY KEY, name TEXT, purpose TEXT)'
+    'keys': 'CREATE TABLE IF NOT EXISTS keys (id INTEGER PRIMARY KEY, name TEXT, purpose TEXT)',
+    'keyword_usage': 'CREATE TABLE IF NOT EXISTS keyword_usage (clone_id TEXT, keyword TEXT, count INTEGER, PRIMARY KEY (clone_id, keyword))'
 }
 
 def setup_database():


### PR DESCRIPTION
## Summary
- add `read_keyword_usage.py` to print saved keyword usage stats
- document how to use the new script in the README

## Testing
- `python -m py_compile keyword_stats_to_db.py setup_database.py read_keyword_usage.py`
- `python setup_database.py`
- `python read_keyword_usage.py`
- `python keyword_stats_to_db.py` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_6887d374e5ac832fadbd47018a6c4f8b