### PR TITLE
Add simple screen_chat interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,13 @@ To hear the responses spoken aloud, add the `--speak` flag (requires pyttsx3):
 python "OK workspaces/cli.py" --speak
 ```
 
+For a minimal text-only chat that simply prints each response on the screen, you can run:
+
+```bash
+python screen_chat.py
+```
+Add `--speak` to also vocalize the output with `espeak` if available.
+
 ### Gmail Integration
 Set the following environment variables so Hecate can send and receive email via Gmail:
 

--- a/screen_chat.py
+++ b/screen_chat.py
@@ -1,0 +1,44 @@
+import argparse
+import os
+import sys
+
+# Add the 'OK workspaces' directory to sys.path
+repo_dir = os.path.dirname(os.path.abspath(__file__))
+work_dir = os.path.join(repo_dir, 'OK workspaces')
+if work_dir not in sys.path:
+    sys.path.insert(0, work_dir)
+
+from hecate import Hecate
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Simple on-screen chat with Hecate")
+    parser.add_argument("--speak", action="store_true", help="Speak responses aloud")
+    args = parser.parse_args()
+
+    bot = Hecate()
+    intro = bot.startup_message()
+    if intro:
+        print(intro)
+    while True:
+        try:
+            user_input = input("You: ").strip()
+        except (EOFError, KeyboardInterrupt):
+            print()
+            break
+        if not user_input:
+            continue
+        if user_input.lower() in {"quit", "exit"}:
+            break
+        reply = bot.respond(user_input)
+        print(reply)
+        if args.speak:
+            try:
+                import subprocess
+                subprocess.run(["espeak", reply], check=True)
+            except Exception:
+                pass
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `screen_chat.py` for lightweight console-based interaction
- document new script in README

## Testing
- `python -m py_compile screen_chat.py`
- `python screen_chat.py --help`


------
https://chatgpt.com/codex/tasks/task_e_6887dcba3578832fb27c2b36142c8dd0